### PR TITLE
fix(ably-grid-02): enhances the reder of online users based on custom…

### DIFF
--- a/src/components/AvatarStack/AvatarStack.tsx
+++ b/src/components/AvatarStack/AvatarStack.tsx
@@ -10,56 +10,24 @@ import Surplus from './Surplus'
 
 dayjs.extend(relativeTime)
 
+export interface presenceUserWithColor extends Types.PresenceMessage {
+  color: string
+}
+interface AvatarStackProps {
+  channelName: string
+  clientId: string
+  presenceUsers: presenceUserWithColor[]
+}
+
 const AvatarStack = ({
   channelName,
   clientId,
   presenceUsers,
-}: {
-  channelName: string
-  clientId: string
-  presenceUsers: Types.PresenceMessage[]
-}) => {
-  const [pastUsers, setPastUsers] = useState<Types.PresenceMessage[]>([])
-
-  // 💡 This is used to access Ably's `channel.presence.history`
-  const [channel] = useChannel(channelName, () => {})
-
-  // 💡 Effect to set past users from the Ably presence history
-  useEffect(() => {
-    if (presenceUsers.length >= 1) {
-      channel.presence.history((err, result) => {
-        const pastUsers = result?.items.filter(
-          (resultItem) => resultItem.action === 'leave'
-        )
-
-        setPastUsers(pastUsers || [])
-      })
-    }
-  }, [presenceUsers])
-
-  // 💡 Effect to remove users who have left more than 2 minutes ago using the Ably presence history
-  useEffect(() => {
-    if (pastUsers.length > 0) {
-      setTimeout(() => {
-        channel.presence.history((err, result) => {
-          const leftUsers = result?.items.filter(
-            (user) =>
-              user.action === 'leave' &&
-              Math.floor((Date.now() - user.timestamp) / 1000) >
-                REMOVE_USER_AFTER_MILLIS
-          )
-
-          setPastUsers(leftUsers || [])
-        })
-      }, REMOVE_USER_AFTER_MILLIS + 5000)
-    }
-  }, [pastUsers.length])
-
+}: AvatarStackProps) => {
   const otherUsers = [
     ...presenceUsers.filter(
       (presenceUser) => presenceUser.clientId !== clientId
     ),
-    ...pastUsers,
   ].filter((val, index, arr) => arr.indexOf(val) === index)
 
   return (

--- a/src/components/AvatarStack/Avatars.tsx
+++ b/src/components/AvatarStack/Avatars.tsx
@@ -7,6 +7,11 @@ import { MAX_USERS_BEFORE_LIST } from './utils/constants'
 
 import UserInfo from './UserInfo'
 
+// Move this to itsown folder
+interface presenceUserWithColor extends Types.PresenceMessage {
+  color: string
+}
+
 const YouAvatar = () => (
   <div className="group relative flex flex-col items-center group">
     <UserCircleIcon className="absolute mt-2 h-8 w-8 opacity-80 text-white pointer-events-none" />
@@ -20,7 +25,7 @@ const YouAvatar = () => (
   </div>
 )
 
-const Avatars = ({ otherUsers }: { otherUsers: Types.PresenceMessage[] }) => {
+const Avatars = ({ otherUsers }: { otherUsers: presenceUserWithColor[] }) => {
   const [hoveredClientId, setHoveredClientId] = useState<string | null>(null)
 
   return (
@@ -34,6 +39,8 @@ const Avatars = ({ otherUsers }: { otherUsers: Types.PresenceMessage[] }) => {
             otherUsers.length > MAX_USERS_BEFORE_LIST
               ? (index + 1) * HORIZONTAL_SPACING_OFFSET
               : index * HORIZONTAL_SPACING_OFFSET
+
+          const userColorClasses = `from-${user.color}-400 to-${user.color}-500`
           return (
             <div
               className="absolute right-0 flex flex-col items-center"
@@ -45,7 +52,7 @@ const Avatars = ({ otherUsers }: { otherUsers: Types.PresenceMessage[] }) => {
             >
               <UserCircleIcon className="absolute mt-2 h-8 w-8 opacity-80 stroke-white fill-transparent pointer-events-none" />
               <div
-                className={`bg-gradient-to-l ${colours[index]} h-12 w-12 rounded-full mb-2 shadow-[0_0_0_4px_rgba(255,255,255,1)]`}
+                className={`bg-gradient-to-l ${userColorClasses} h-12 w-12 rounded-full mb-2 shadow-[0_0_0_4px_rgba(255,255,255,1)]`}
                 onMouseOver={() => setHoveredClientId(user.clientId)}
                 onMouseLeave={() => setHoveredClientId(null)}
               ></div>

--- a/src/components/AvatarStack/Grid/components/CustomCellRender/CustomCellRender.tsx
+++ b/src/components/AvatarStack/Grid/components/CustomCellRender/CustomCellRender.tsx
@@ -1,0 +1,35 @@
+import { ICellRendererParams } from '@ag-grid-community/core'
+import getOthersOnlineUsersPointer from '../../../utils/getOnlineUsersData'
+
+const CustomCellRender = (props: ICellRendererParams) => {
+  const { context, rowIndex, colDef } = props
+  const cellValue = props.valueFormatted ? props.valueFormatted : props.value
+  const othersOnlineUsersPointer = getOthersOnlineUsersPointer(
+    context.presenceUsers,
+    context.clientId
+  )
+
+  const userPointerInCell = othersOnlineUsersPointer.find(
+    (user: any) =>
+      rowIndex === user.data?.pointer?.rowEndIndex &&
+      colDef?.field === user.data?.pointer?.columnEnd
+  )
+  const cellBasicClass = 'relative h-full w-full'
+
+  const cellClass = userPointerInCell ? `border-dashed border-2` : ''
+
+  return (
+    <div
+      className={`${cellBasicClass} ${cellClass}`}
+      style={{
+        borderColor: userPointerInCell ? userPointerInCell.color : 'inherit',
+        left: '-18px',
+        paddingLeft: '18px',
+      }}
+    >
+      <span>{cellValue}</span>
+    </div>
+  )
+}
+
+export default CustomCellRender

--- a/src/components/AvatarStack/Grid/components/CustomCellRender/index.tsx
+++ b/src/components/AvatarStack/Grid/components/CustomCellRender/index.tsx
@@ -1,0 +1,3 @@
+import CustomCellRender from './CustomCellRender'
+
+export default CustomCellRender

--- a/src/components/AvatarStack/Project.tsx
+++ b/src/components/AvatarStack/Project.tsx
@@ -1,13 +1,15 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { useOutletContext } from 'react-router-dom'
 
 import type { ProjectInfo } from '../../Layout'
 import AvatarStack from './AvatarStack'
 import { usePresence, useChannel } from '@ably-labs/react-hooks'
-import { fakeNames } from './utils/fakeData'
+import { fakeNames, colors } from './utils/fakeData'
 import Grid from './Grid'
+import type { Types } from 'ably'
 
 const fakeName = () => fakeNames[Math.floor(Math.random() * fakeNames.length)]
+const getRdmColor = () => colors[Math.floor(Math.random() * colors.length)]
 
 const Project = () => {
   const { channelName, clientId, setProjectInfo } = useOutletContext<{
@@ -15,6 +17,14 @@ const Project = () => {
     clientId: string
     setProjectInfo: (projectInfo: ProjectInfo) => void
   }>()
+
+  // 💡 Connect current user to Ably Presence with a random fake name
+  const [presenceUsers, updatePresenceUser] = usePresence(channelName, {
+    name: fakeName(),
+  })
+
+  const [channel] = useChannel(channelName, () => {})
+  const [usersAvatar, setUsersAvatar] = useState<any[]>([])
 
   // 💡 Project specific wiring for showing this example.
   useEffect(() => {
@@ -25,22 +35,43 @@ const Project = () => {
     })
   }, [])
 
-  // 💡 Connect current user to Ably Presence with a random fake name
-  const [presenceUsers, updatePresenceUser] = usePresence(channelName, {
-    name: fakeName(),
-  })
+  useEffect(() => {
+    if (presenceUsers.length >= 1) {
+      const onlineUsers = presenceUsers.filter(
+        (resultItem: Types.PresenceMessage) => resultItem.action === 'present'
+      )
+
+      const updatedUsersAvatar = onlineUsers.map(
+        (userItem: Types.PresenceMessage) => {
+          const currentUserAvatar = usersAvatar.find(
+            (userAvatar) => userAvatar.clientId === userItem.clientId
+          )
+          if (currentUserAvatar) {
+            return { ...userItem, color: currentUserAvatar.color }
+          }
+
+          if (userItem.clientId === clientId) {
+            return { ...userItem, color: 'blue' }
+          }
+
+          return { ...userItem, color: getRdmColor() }
+        }
+      )
+      setUsersAvatar(updatedUsersAvatar)
+    }
+  }, [presenceUsers])
 
   return (
     <div className="h-screen flex flex-col">
       <AvatarStack
         channelName={channelName}
         clientId={clientId}
-        presenceUsers={presenceUsers}
+        presenceUsers={usersAvatar}
       />
       <Grid
         channelName={channelName}
         clientId={clientId}
-        presenceUsers={presenceUsers}
+        presenceUsers={usersAvatar}
         updatePresenceUser={updatePresenceUser}
       />
     </div>

--- a/src/components/AvatarStack/utils/fakeData.ts
+++ b/src/components/AvatarStack/utils/fakeData.ts
@@ -121,3 +121,5 @@ export const colours = [
   'from-rose-400 to-rose-500',
   'from-lime-400 to-lime-500',
 ]
+
+export const colors = ['orange', 'pink', 'green', 'violet', 'rose', 'lime']

--- a/src/components/AvatarStack/utils/getOnlineUsersData.ts
+++ b/src/components/AvatarStack/utils/getOnlineUsersData.ts
@@ -1,0 +1,17 @@
+import type { Types } from 'ably'
+
+const getOthersOnlineUsersPointer = (presenceUsers: any, clientId: string) => {
+  if (presenceUsers.length > 1) {
+    return (
+      presenceUsers.filter(
+        (resultItem: Types.PresenceMessage) =>
+          resultItem.action === 'present' &&
+          resultItem.clientId !== clientId &&
+          resultItem.data.pointer
+      ) || []
+    )
+  }
+  return []
+}
+
+export default getOthersOnlineUsersPointer


### PR DESCRIPTION
So during the exploration of letting a grid user know the position of other online users looking into the same grid, I found that the Ag grid library does not have a direct API method to print multiple cell range selections with a flexible level of customization. This limitation pushed me to use the **cellRenderer** property in **colDef** to find a workaround for the primary goal. 

With the help of some Js logic, I could dynamically render a custom dashed border around those cells that represent the positions of other users in the grid. I also could use the same color that the Avatar component used to distinguish the positions of online users inside the grid.


![Screen Shot 2023-04-05 at 4 37 48 PM](https://user-images.githubusercontent.com/6549451/230217931-c9454d12-3693-4bc4-b4b4-cb6b21bf16c1.png)


